### PR TITLE
Supports reg/real and string value changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vcd"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kevin Mehall <km@kevinmehall.net>"]
 description = "Read and write VCD (Value Change Dump) files"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,23 @@ impl Display for ScopeType {
 /// A type of variable, as used in the `$var` command
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum VarType {
+    //Event,
+    //Integer,
+    //Parameter,
+    Real,
+    Reg,
+    //Supply0,
+    //Supply1,
+    //Time,
+    //Tri,
+    //Triant,
+    //Trior,
+    //Trireg,
+    //Tri0,
+    //Tri1,
+    //Wand,
     Wire,
+    //Wor,
 }
 
 impl FromStr for VarType {
@@ -141,7 +157,9 @@ impl FromStr for VarType {
         use self::VarType::*;
         match s {
             "wire" => Ok(Wire),
-            _ => Err(Error::Parse("Invalid scope type"))
+            "reg" => Ok(Reg),
+            "real" => Ok(Real),
+            _ => Err(Error::Parse("Invalid var type"))
         }
     }
 }
@@ -151,6 +169,8 @@ impl Display for VarType {
         use self::VarType::*;
         write!(f, "{}", match *self {
             Wire => "wire",
+            Reg => "reg",
+            Real => "real",
         })
     }
 }
@@ -260,6 +280,9 @@ pub enum Command {
 
     /// A `r1.234 a` change to a real variable
     ChangeReal(IdCode, f64),
+
+    /// A `sSTART a` change to a (real?) variable
+    ChangeString(IdCode, String),
 
     /// A beginning of a simulation command. Unlike header commands, which are parsed atomically,
     /// simulation commands emit a Begin, followed by the data changes within them, followed by

--- a/src/read.rs
+++ b/src/read.rs
@@ -252,6 +252,12 @@ impl<R: io::Read> Parser<R> {
         Ok(Command::ChangeReal(id, val))
     }
 
+    fn parse_string(&mut self) -> Result<Command, Error> {
+        let val = try!(self.read_token_string());
+        let id = try!(self.read_token_parse());
+        Ok(Command::ChangeString(id, val))
+    }
+
     fn parse_scope(&mut self, scope_type: ScopeType, reference: String) -> Result<Scope, Error> {
         use super::Command::*;
         let mut children = Vec::new();
@@ -317,6 +323,7 @@ impl<P: io::Read> Iterator for Parser<P> {
                 b'0' | b'1' | b'z' | b'Z' | b'x' | b'X' => return Some(self.parse_scalar(b)),
                 b'b' | b'B' => return Some(self.parse_vector()),
                 b'r' | b'R' => return Some(self.parse_real()),
+                b's' | b'S' => return Some(self.parse_string()),
                 _ => panic!("Unexpected character {}", b)
             }
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -120,6 +120,11 @@ impl<'s> Writer<'s> {
         writeln!(self.writer, "r{} {}", v, id)
     }
 
+    /// Write a change to a string variable
+    pub fn change_string(&mut self, id: IdCode, v: &str) -> io::Result<()> {
+        writeln!(self.writer, "s{} {}", v, id)
+    }
+
     /// Write the beginning of a simulation command
     pub fn begin(&mut self, c: SimulationCommand) -> io::Result<()> {
         writeln!(self.writer, "${}", c)
@@ -146,6 +151,7 @@ impl<'s> Writer<'s> {
             ChangeScalar(i, v) => self.change_scalar(i, v),
             ChangeVector(i, ref v) => self.change_vector(i, &v[..]),
             ChangeReal(i, v) => self.change_real(i, v),
+            ChangeString(i, ref v) => self.change_string(i, v),
             Begin(c) => self.begin(c),
             End(_) => self.end(),
         }


### PR DESCRIPTION
This is to support parsing file, generated by MyHDL and supported by GtkWave.

[tb.vcd.zip](https://github.com/kevinmehall/rust-vcd/files/388407/tb.vcd.zip)

I couldn't find the "string" value in Verilog-2001 but it calls it a "real" anyway, so I am assuming it's a hack.

(hey @kevinmehall!)
