### PR TITLE
Allow for spaces in Variable references

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -7,6 +7,7 @@ use {
     ScopeType,
     Scope,
     Var,
+    ReferenceIndex,
     ScopeItem,
     SimulationCommand,
     Header,
@@ -107,6 +108,16 @@ impl<R: io::Read> Parser<R> {
         Ok(s.trim().to_string()) // TODO: don't reallocate
     }
 
+    fn read_reference_index_end(&mut self) -> Result<Option<ReferenceIndex>, io::Error> {
+        let mut buf = [0;32];
+        let tok = self.read_token_str(&mut buf)?;
+        if tok.as_bytes() == b"$end" { return Ok(None); }
+
+        let index: ReferenceIndex = tok.parse()?;
+        self.read_command_end()?;
+        return Ok(Some(index));
+    }
+
     fn parse_command(&mut self) -> Result<Command, io::Error> {
         use super::Command::*;
         use super::SimulationCommand::*;
@@ -145,8 +156,9 @@ impl<R: io::Read> Parser<R> {
                 let var_type = self.read_token_parse()?;
                 let size = self.read_token_parse()?;
                 let code = self.read_token_parse()?;
-                let reference = self.read_string_command()?;
-                Ok(VarDef(var_type, size, code, reference))
+                let reference = self.read_token_string()?;
+                let index = self.read_reference_index_end()?;
+                Ok(VarDef(var_type, size, code, reference, index))
             }
             b"enddefinitions" => {
                 self.read_command_end()?;
@@ -221,9 +233,9 @@ impl<R: io::Read> Parser<R> {
                 Some(Ok(ScopeDef(tp, id))) => {
                     children.push(ScopeItem::Scope(self.parse_scope(tp, id)?));
                 }
-                Some(Ok(VarDef(tp, size, id, r))) => {
+                Some(Ok(VarDef(tp, size, id, r, idx))) => {
                     children.push(ScopeItem::Var(
-                        Var { var_type: tp, size: size, code: id, reference: r }
+                        Var { var_type: tp, size: size, code: id, reference: r , index: idx}
                     ));
                 }
                 Some(Ok(_)) => return Err(InvalidData("unexpected command in $scope").into()),
@@ -249,9 +261,9 @@ impl<R: io::Read> Parser<R> {
                 Some(Ok(Date(s)))    => { header.date    = Some(s); }
                 Some(Ok(Version(s))) => { header.version = Some(s); }
                 Some(Ok(Timescale(val, unit))) => { header.timescale = Some((val, unit)); }
-                Some(Ok(VarDef(var_type, size, code, reference))) => {
+                Some(Ok(VarDef(var_type, size, code, reference, index))) => {
                     header.items.push(ScopeItem::Var(
-                        Var { var_type, size, code, reference }
+                        Var { var_type, size, code, reference, index }
                     ));
                 }
                 Some(Ok(ScopeDef(tp, id))) => {
@@ -302,6 +314,7 @@ mod test {
     use ::{ TimescaleUnit, IdCode, VarType, ScopeType };
     use super::Parser;
     use super::ScopeItem;
+    use super::ReferenceIndex;
 
     #[test]
     fn wikipedia_sample() {
@@ -407,6 +420,7 @@ mod test {
         let sample = b"
 $scope module top $end
 $var wire 1 ! i_vld [0] $end
+$var wire 10 ~ i_data [9:0] $end
 $upscope $end
 $enddefinitions $end
 #0
@@ -424,8 +438,18 @@ $enddefinitions $end
 
         if let ScopeItem::Var(ref v) = scope.children[0] {
             assert_eq!(v.var_type, VarType::Wire);
-            assert_eq!(&v.reference[..], "i_vld [0]");
+            assert_eq!(&v.reference[..], "i_vld");
+            assert_eq!(v.index, Some(ReferenceIndex::BitSelect(0)));
             assert_eq!(v.size, 1);
+        } else {
+            panic!("Expected Var, found {:?}", scope.children[0]);
+        }
+
+        if let ScopeItem::Var(ref v) = scope.children[1] {
+            assert_eq!(v.var_type, VarType::Wire);
+            assert_eq!(&v.reference[..], "i_data");
+            assert_eq!(v.index, Some(ReferenceIndex::Range(9,0)));
+            assert_eq!(v.size, 10);
         } else {
             panic!("Expected Var, found {:?}", scope.children[0]);
         }
@@ -551,12 +575,14 @@ b1 n0
             size: 32,
             code: IdCode(83),
             reference: "smt_step".into(),
+            index: None,
         }));
         assert_eq!(header.items[1], ScopeItem::Var(Var {
             var_type: VarType::Event,
             size: 1,
             code: IdCode(0),
             reference: "smt_clock".into(),
+            index: None,
         }));
 
         let scope = match &header.items[2] {

--- a/src/write.rs
+++ b/src/write.rs
@@ -6,6 +6,7 @@ use {
     IdCode,
     Scope,
     Var,
+    ReferenceIndex,
     ScopeItem,
     SimulationCommand,
     Header,
@@ -101,20 +102,23 @@ impl<'s> Writer<'s> {
     }
 
     /// Writes a `$var` command with a specified id.
-    pub fn var_def(&mut self, var_type: VarType, width: u32, id: IdCode, reference: &str) -> io::Result<()> {
+    pub fn var_def(&mut self, var_type: VarType, width: u32, id: IdCode, reference: &str, index: Option<ReferenceIndex>) -> io::Result<()> {
         debug_assert!(self.scope_depth > 0, "Generating invalid VCD: variable must be in a scope");
         if id >= self.next_id_code {
             self.next_id_code = id.next();
         }
-        writeln!(self.writer, "$var {} {} {} {} $end", var_type, width, id, reference)
+        match index {
+            Some(idx) => writeln!(self.writer, "$var {} {} {} {} {}$end", var_type, width, id, reference, idx),
+            None => writeln!(self.writer, "$var {} {} {} {} $end", var_type, width, id, reference),
+        }
     }
 
     /// Writes a `$var` command with the next available ID, returning the assigned ID.
     ///
     /// Convenience wrapper around `var_def`.
-    pub fn add_var(&mut self, var_type: VarType, width: u32, reference: &str) -> io::Result<IdCode> {
+    pub fn add_var(&mut self, var_type: VarType, width: u32, reference: &str, index: Option<ReferenceIndex>) -> io::Result<IdCode> {
         let id = self.next_id_code;
-        self.var_def(var_type, width, id, reference)?;
+        self.var_def(var_type, width, id, reference, index)?;
         Ok(id)
     }
 
@@ -122,12 +126,12 @@ impl<'s> Writer<'s> {
     ///
     /// Convenience wrapper around `add_var`.
     pub fn add_wire(&mut self, width: u32, reference: &str) -> io::Result<IdCode> {
-        self.add_var(VarType::Wire, width, reference)
+        self.add_var(VarType::Wire, width, reference, None)
     }
 
     /// Writes a `$var` command from a `Var` structure from the parser.
     pub fn var(&mut self, v: &Var) -> io::Result<()> {
-        self.var_def(v.var_type, v.size, v.code, &v.reference[..])
+        self.var_def(v.var_type, v.size, v.code, &v.reference[..], v.index)
     }
 
     /// Writes a `$enddefinitions` command to end the header.
@@ -183,7 +187,7 @@ impl<'s> Writer<'s> {
             Timescale(v, u) => self.timescale(v, u),
             ScopeDef(t, ref i) => self.scope_def(t, &i[..]),
             Upscope => self.upscope(),
-            VarDef(t, s, i, ref r) => self.var_def(t, s, i, &r[..]),
+            VarDef(t, s, i, ref r, idx) => self.var_def(t, s, i, &r[..], idx),
             Enddefinitions => self.enddefinitions(),
             Timestamp(t) => self.timestamp(t),
             ChangeScalar(i, v) => self.change_scalar(i, v),


### PR DESCRIPTION
This PR would allow spaces in variable names, which ModelSim generates for VHDL vectors.