### PR TITLE
Add string to VarType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["vcd", "verilog", "eda"]
 repository = "https://github.com/kevinmehall/rust-vcd"
 categories = ["parser-implementations", "encoding"]
 readme = "README.md"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "kevinmehall/rust-vcd" }

--- a/src/bin/vcd-reformat.rs
+++ b/src/bin/vcd-reformat.rs
@@ -1,4 +1,4 @@
-extern crate vcd;
+use vcd;
 use std::io;
 
 /// A simple demo that uses the reader and writer to round-trip a VCD file from stdin to stdout

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,6 +305,7 @@ pub enum VarType {
     WAnd,
     Wire,
     WOr,
+    String,
 }
 
 impl FromStr for VarType {
@@ -329,6 +330,7 @@ impl FromStr for VarType {
             "wand" => Ok(WAnd),
             "wire" => Ok(Wire),
             "wor" => Ok(WOr),
+            "string" => Ok(String),
             _ => Err(InvalidData("invalid variable type")),
         }
     }
@@ -358,6 +360,7 @@ impl Display for VarType {
                 WAnd => "wand",
                 Wire => "wire",
                 WOr => "wor",
+                String => "string",
             }
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,10 +93,10 @@ use std::io;
 use std::str::FromStr;
 
 mod read;
-pub use read::Parser;
+pub use crate::read::Parser;
 
 mod write;
-pub use write::Writer;
+pub use crate::write::Writer;
 
 /// A unit of time for the `$timescale` command.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -113,7 +113,7 @@ pub enum TimescaleUnit {
 #[derive(Debug)]
 pub struct InvalidData(&'static str);
 impl Display for InvalidData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -145,7 +145,7 @@ impl FromStr for TimescaleUnit {
 }
 
 impl Display for TimescaleUnit {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::TimescaleUnit::*;
         write!(
             f,
@@ -198,7 +198,7 @@ pub enum Value {
 
 impl Value {
     fn parse(v: u8) -> Result<Value, InvalidData> {
-        use Value::*;
+        use crate::Value::*;
         match v {
             b'0' => Ok(V0),
             b'1' => Ok(V1),
@@ -228,8 +228,8 @@ impl From<bool> for Value {
 }
 
 impl Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Value::*;
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use crate::Value::*;
         write!(
             f,
             "{}",
@@ -269,7 +269,7 @@ impl FromStr for ScopeType {
 }
 
 impl Display for ScopeType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::ScopeType::*;
         write!(
             f,
@@ -335,7 +335,7 @@ impl FromStr for VarType {
 }
 
 impl Display for VarType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::VarType::*;
         write!(
             f,
@@ -419,11 +419,11 @@ impl From<u64> for IdCode {
 }
 
 impl Display for IdCode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut i = self.0;
         loop {
             let r = i % NUM_ID_CHARS;
-            try!(write!(f, "{}", (r as u8 + ID_CHAR_MIN) as char));
+            write!(f, "{}", (r as u8 + ID_CHAR_MIN) as char)?;
             if i < NUM_ID_CHARS {
                 break;
             }
@@ -502,8 +502,8 @@ impl FromStr for ReferenceIndex {
     type Err = std::io::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim_start_matches('[').trim_end_matches(']');
-        use io::{Error, ErrorKind};
-        use ReferenceIndex::*;
+        use crate::io::{Error, ErrorKind};
+        use crate::ReferenceIndex::*;
         match s.find(':') {
             Some(idx) => {
                 let msb: u32 = s[..idx]
@@ -529,8 +529,8 @@ impl FromStr for ReferenceIndex {
 }
 
 impl Display for ReferenceIndex {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use ReferenceIndex::*;
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use crate::ReferenceIndex::*;
         match self {
             BitSelect(idx) => write!(f, "[{}]", idx)?,
             Range(msb, lsb) => write!(f, "[{}:{}]", msb, lsb)?,
@@ -617,7 +617,7 @@ pub enum SimulationCommand {
 }
 
 impl Display for SimulationCommand {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::SimulationCommand::*;
         write!(
             f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate reads and writes [VCD (Value Change Dump)][wp] files, a common format used with
 //! logic analyzers, HDL simulators, and other EDA tools.
-//! 
+//!
 //! [wp]: https://en.wikipedia.org/wiki/Value_change_dump
 //!
 //! ## Example
@@ -87,10 +87,10 @@
 //! assert_eq!(value, data);
 //! ```
 
-use std::str::FromStr;
-use std::fmt::{self, Display};
 use std::error::Error;
+use std::fmt::{self, Display};
 use std::io;
+use std::str::FromStr;
 
 mod read;
 pub use read::Parser;
@@ -101,20 +101,31 @@ pub use write::Writer;
 /// A unit of time for the `$timescale` command.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TimescaleUnit {
-    S, MS, US, NS, PS, FS,
+    S,
+    MS,
+    US,
+    NS,
+    PS,
+    FS,
 }
 
 /// Error wrapping a static string message explaining why parsing failed.
 #[derive(Debug)]
 pub struct InvalidData(&'static str);
 impl Display for InvalidData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 impl Error for InvalidData {
-    fn description(&self) -> &str { self.0 }
+    fn description(&self) -> &str {
+        self.0
+    }
 }
 impl From<InvalidData> for io::Error {
-    fn from(e: InvalidData) -> io::Error { io::Error::new(io::ErrorKind::InvalidData, e.0) }
+    fn from(e: InvalidData) -> io::Error {
+        io::Error::new(io::ErrorKind::InvalidData, e.0)
+    }
 }
 
 impl FromStr for TimescaleUnit {
@@ -122,13 +133,13 @@ impl FromStr for TimescaleUnit {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use self::TimescaleUnit::*;
         match s {
-            "s"  => Ok(S),
+            "s" => Ok(S),
             "ms" => Ok(MS),
             "us" => Ok(US),
             "ns" => Ok(NS),
             "ps" => Ok(PS),
             "fs" => Ok(FS),
-            _ => Err(InvalidData("invalid timescale unit"))
+            _ => Err(InvalidData("invalid timescale unit")),
         }
     }
 }
@@ -136,14 +147,18 @@ impl FromStr for TimescaleUnit {
 impl Display for TimescaleUnit {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::TimescaleUnit::*;
-        write!(f, "{}", match *self {
-            S  => "s",
-            MS => "ms",
-            US => "us",
-            NS => "ns",
-            PS => "ps",
-            FS => "fs",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                S => "s",
+                MS => "ms",
+                US => "us",
+                NS => "ns",
+                PS => "ps",
+                FS => "fs",
+            }
+        )
     }
 }
 
@@ -151,7 +166,7 @@ impl TimescaleUnit {
     pub fn divisor(&self) -> u64 {
         use self::TimescaleUnit::*;
         match *self {
-            S  => 1,
+            S => 1,
             MS => 1_000,
             US => 1_000_000,
             NS => 1_000_000_000,
@@ -163,7 +178,7 @@ impl TimescaleUnit {
     pub fn fraction(&self) -> f64 {
         1.0 / (self.divisor() as f64)
     }
- }
+}
 
 /// A four-valued logic scalar value.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -189,7 +204,7 @@ impl Value {
             b'1' => Ok(V1),
             b'x' | b'X' => Ok(X),
             b'z' | b'Z' => Ok(Z),
-            _ => Err(InvalidData("invalid VCD value"))
+            _ => Err(InvalidData("invalid VCD value")),
         }
     }
 }
@@ -204,19 +219,27 @@ impl FromStr for Value {
 impl From<bool> for Value {
     /// `true` converts to `V1`, `false` to `V0`
     fn from(v: bool) -> Value {
-        if v { Value::V1 } else { Value::V0 }
+        if v {
+            Value::V1
+        } else {
+            Value::V0
+        }
     }
 }
 
 impl Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use Value::*;
-        write!(f, "{}", match *self {
-            V0 => "0",
-            V1 => "1",
-            X => "x",
-            Z => "z",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                V0 => "0",
+                V1 => "1",
+                X => "x",
+                Z => "z",
+            }
+        )
     }
 }
 
@@ -240,7 +263,7 @@ impl FromStr for ScopeType {
             "function" => Ok(Function),
             "begin" => Ok(Begin),
             "fork" => Ok(Fork),
-            _ => Err(InvalidData("invalid scope type"))
+            _ => Err(InvalidData("invalid scope type")),
         }
     }
 }
@@ -248,13 +271,17 @@ impl FromStr for ScopeType {
 impl Display for ScopeType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::ScopeType::*;
-        write!(f, "{}", match *self {
-            Module => "module",
-            Task  => "task",
-            Function => "function",
-            Begin  => "begin",
-            Fork  => "fork",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                Module => "module",
+                Task => "task",
+                Function => "function",
+                Begin => "begin",
+                Fork => "fork",
+            }
+        )
     }
 }
 
@@ -302,7 +329,7 @@ impl FromStr for VarType {
             "wand" => Ok(WAnd),
             "wire" => Ok(Wire),
             "wor" => Ok(WOr),
-            _ => Err(InvalidData("invalid variable type"))
+            _ => Err(InvalidData("invalid variable type")),
         }
     }
 }
@@ -310,25 +337,29 @@ impl FromStr for VarType {
 impl Display for VarType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::VarType::*;
-        write!(f, "{}", match *self {
-            Event => "event",
-            Integer => "integer",
-            Parameter => "parameter",
-            Real => "real",
-            Reg => "reg",
-            Supply0 => "supply0",
-            Supply1 => "supply1",
-            Time => "time",
-            Tri => "tri",
-            TriAnd => "triand",
-            TriOr => "trior",
-            TriReg => "trireg",
-            Tri0 => "tri0",
-            Tri1 => "tri1",
-            WAnd => "wand",
-            Wire => "wire",
-            WOr => "wor",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                Event => "event",
+                Integer => "integer",
+                Parameter => "parameter",
+                Real => "real",
+                Reg => "reg",
+                Supply0 => "supply0",
+                Supply1 => "supply1",
+                Time => "time",
+                Tri => "tri",
+                TriAnd => "triand",
+                TriOr => "trior",
+                TriReg => "trireg",
+                Tri0 => "tri0",
+                Tri1 => "tri1",
+                WAnd => "wand",
+                Wire => "wire",
+                WOr => "wor",
+            }
+        )
     }
 }
 
@@ -342,12 +373,18 @@ const NUM_ID_CHARS: u64 = (ID_CHAR_MAX - ID_CHAR_MIN + 1) as u64;
 
 impl IdCode {
     fn new(v: &[u8]) -> Result<IdCode, InvalidData> {
-        if v.is_empty() { return Err(InvalidData("ID cannot be empty")) }
+        if v.is_empty() {
+            return Err(InvalidData("ID cannot be empty"));
+        }
         let mut result = 0u64;
         for &i in v.iter().rev() {
-            if i < ID_CHAR_MIN || i > ID_CHAR_MAX { return Err(InvalidData("invalid characters in ID")) }
+            if i < ID_CHAR_MIN || i > ID_CHAR_MAX {
+                return Err(InvalidData("invalid characters in ID"));
+            }
             let c = ((i - ID_CHAR_MIN) as u64) + 1;
-            result = result.checked_mul(NUM_ID_CHARS).and_then(|x| x.checked_add(c))
+            result = result
+                .checked_mul(NUM_ID_CHARS)
+                .and_then(|x| x.checked_add(c))
                 .ok_or(InvalidData("ID too long"))?;
         }
         Ok(IdCode(result - 1))
@@ -370,11 +407,15 @@ impl FromStr for IdCode {
 }
 
 impl From<u32> for IdCode {
-    fn from(i: u32) -> IdCode { IdCode(i as u64) }
+    fn from(i: u32) -> IdCode {
+        IdCode(i as u64)
+    }
 }
 
 impl From<u64> for IdCode {
-    fn from(i: u64) -> IdCode { IdCode(i) }
+    fn from(i: u64) -> IdCode {
+        IdCode(i)
+    }
 }
 
 impl Display for IdCode {
@@ -383,7 +424,9 @@ impl Display for IdCode {
         loop {
             let r = i % NUM_ID_CHARS;
             try!(write!(f, "{}", (r as u8 + ID_CHAR_MIN) as char));
-            if i < NUM_ID_CHARS { break; }
+            if i < NUM_ID_CHARS {
+                break;
+            }
             i = i / NUM_ID_CHARS - 1;
         }
         Ok(())
@@ -400,10 +443,19 @@ fn test_id_code() {
     }
 
     assert_eq!("!".parse::<IdCode>().unwrap().to_string(), "!");
-    assert_eq!("!!!!!!!!!!".parse::<IdCode>().unwrap().to_string(), "!!!!!!!!!!");
+    assert_eq!(
+        "!!!!!!!!!!".parse::<IdCode>().unwrap().to_string(),
+        "!!!!!!!!!!"
+    );
     assert_eq!("~".parse::<IdCode>().unwrap().to_string(), "~");
-    assert_eq!("~~~~~~~~~".parse::<IdCode>().unwrap().to_string(), "~~~~~~~~~");
-    assert_eq!("n999999999".parse::<IdCode>().unwrap().to_string(), "n999999999");
+    assert_eq!(
+        "~~~~~~~~~".parse::<IdCode>().unwrap().to_string(),
+        "~~~~~~~~~"
+    );
+    assert_eq!(
+        "n999999999".parse::<IdCode>().unwrap().to_string(),
+        "n999999999"
+    );
     assert!("n9999999999".parse::<IdCode>().is_err());
 }
 
@@ -412,7 +464,7 @@ fn test_id_code() {
 pub struct Scope {
     pub scope_type: ScopeType,
     pub identifier: String,
-    pub children: Vec<ScopeItem>
+    pub children: Vec<ScopeItem>,
 }
 
 impl Scope {
@@ -421,7 +473,7 @@ impl Scope {
         for c in &self.children {
             if let &ScopeItem::Var(ref v) = c {
                 if v.reference == reference {
-                    return Some(v)
+                    return Some(v);
                 }
             }
         }
@@ -431,7 +483,11 @@ impl Scope {
 
 impl Default for Scope {
     fn default() -> Scope {
-        Scope { scope_type: ScopeType::Module, identifier: "".to_string(), children: Vec::new() }
+        Scope {
+            scope_type: ScopeType::Module,
+            identifier: "".to_string(),
+            children: Vec::new(),
+        }
     }
 }
 
@@ -446,16 +502,26 @@ impl FromStr for ReferenceIndex {
     type Err = std::io::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.trim_start_matches('[').trim_end_matches(']');
-        use ReferenceIndex::*;
         use io::{Error, ErrorKind};
+        use ReferenceIndex::*;
         match s.find(':') {
             Some(idx) => {
-                let msb: u32 = s[..idx].trim().parse().map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
-                let lsb: u32 = s[idx..].trim_start_matches(':').trim().parse().map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+                let msb: u32 = s[..idx]
+                    .trim()
+                    .parse()
+                    .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+                let lsb: u32 = s[idx..]
+                    .trim_start_matches(':')
+                    .trim()
+                    .parse()
+                    .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
                 Ok(Range(msb, lsb))
-            },
+            }
             None => {
-                let idx  = s.trim().parse().map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
+                let idx = s
+                    .trim()
+                    .parse()
+                    .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
                 Ok(BitSelect(idx))
             }
         }
@@ -538,7 +604,7 @@ pub enum Command {
     Begin(SimulationCommand),
 
     /// An end of a simulation command.
-    End(SimulationCommand)
+    End(SimulationCommand),
 }
 
 /// A simulation command type, used in `Command::Begin` and `Command::End`.
@@ -553,12 +619,16 @@ pub enum SimulationCommand {
 impl Display for SimulationCommand {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::SimulationCommand::*;
-        write!(f, "{}", match *self {
-            Dumpall  => "dumpall",
-            Dumpoff  => "dumpoff",
-            Dumpon   => "dumpon",
-            Dumpvars => "dumpvars",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                Dumpall => "dumpall",
+                Dumpoff => "dumpoff",
+                Dumpon => "dumpon",
+                Dumpvars => "dumpvars",
+            }
+        )
     }
 }
 
@@ -591,15 +661,19 @@ impl Header {
     /// assert_eq!(scope.identifier, "b");
     /// ```
     pub fn find_scope<S>(&self, path: &[S]) -> Option<&Scope>
-        where S: std::borrow::Borrow<str>
+    where
+        S: std::borrow::Borrow<str>,
     {
         fn find_nested_scope<'a, S>(mut scope: &'a Scope, mut path: &[S]) -> Option<&'a Scope>
-            where S: std::borrow::Borrow<str>
+        where
+            S: std::borrow::Borrow<str>,
         {
             'deeper: while !path.is_empty() {
                 for child in &scope.children {
                     match child {
-                        ScopeItem::Scope(ref new_scope) if new_scope.identifier == path[0].borrow() => {
+                        ScopeItem::Scope(ref new_scope)
+                            if new_scope.identifier == path[0].borrow() =>
+                        {
                             scope = new_scope;
                             path = &path[1..];
                             continue 'deeper;
@@ -618,7 +692,7 @@ impl Header {
 
         let scope = self.items.iter().find(|item| match item {
             ScopeItem::Scope(scope) => scope.identifier == path[0].borrow(),
-            _ => false
+            _ => false,
         });
 
         if let Some(ScopeItem::Scope(scope)) = scope {
@@ -646,9 +720,10 @@ impl Header {
     /// assert_eq!(var.reference, "counter");
     /// ```
     pub fn find_var<S>(&self, path: &[S]) -> Option<&Var>
-        where S: std::borrow::Borrow<str>
+    where
+        S: std::borrow::Borrow<str>,
     {
-        let scope = self.find_scope(&path[..path.len()-1])?;
-        scope.find_var(path[path.len()-1].borrow())
+        let scope = self.find_scope(&path[..path.len() - 1])?;
+        scope.find_var(path[path.len() - 1].borrow())
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -264,7 +264,7 @@ impl<R: io::Read> Parser<R> {
                 Some(Ok(VarDef(tp, size, id, r, idx))) => {
                     children.push(ScopeItem::Var(Var {
                         var_type: tp,
-                        size: size,
+                        size,
                         code: id,
                         reference: r,
                         index: idx,
@@ -282,9 +282,9 @@ impl<R: io::Read> Parser<R> {
         }
 
         Ok(Scope {
-            scope_type: scope_type,
+            scope_type,
             identifier: reference,
-            children: children,
+            children,
         })
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,18 +1,8 @@
-use std::io;
-use std::str::{ FromStr, from_utf8 };
 use super::InvalidData;
+use std::io;
+use std::str::{from_utf8, FromStr};
 
-use {
-    Value,
-    ScopeType,
-    Scope,
-    Var,
-    ReferenceIndex,
-    ScopeItem,
-    SimulationCommand,
-    Header,
-    Command
-};
+use {Command, Header, ReferenceIndex, Scope, ScopeItem, ScopeType, SimulationCommand, Value, Var};
 
 fn whitespace_byte(b: u8) -> bool {
     match b {
@@ -44,7 +34,12 @@ impl<R: io::Read> Parser<R> {
     fn read_byte(&mut self) -> Result<u8, io::Error> {
         match self.bytes_iter.next() {
             Some(b) => b,
-            None => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "unexpected end of VCD file")),
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "unexpected end of VCD file",
+                ))
+            }
         }
     }
 
@@ -53,7 +48,11 @@ impl<R: io::Read> Parser<R> {
         loop {
             let b = self.read_byte()?;
             if whitespace_byte(b) {
-                if len > 0 { break; } else { continue; }
+                if len > 0 {
+                    break;
+                } else {
+                    continue;
+                }
             }
 
             if let Some(p) = buf.get_mut(len) {
@@ -76,30 +75,45 @@ impl<R: io::Read> Parser<R> {
         loop {
             let b = self.read_byte()?;
             if whitespace_byte(b) {
-                if r.len() > 0 { break; } else { continue; }
+                if r.len() > 0 {
+                    break;
+                } else {
+                    continue;
+                }
             }
             r.push(b);
         }
         String::from_utf8(r).map_err(|_| InvalidData("string is not UTF-8").into())
     }
 
-    fn read_token_parse<T>(&mut self) -> Result<T, io::Error> where T: FromStr, <T as FromStr>::Err: 'static + ::std::error::Error + Send + Sync {
+    fn read_token_parse<T>(&mut self) -> Result<T, io::Error>
+    where
+        T: FromStr,
+        <T as FromStr>::Err: 'static + ::std::error::Error + Send + Sync,
+    {
         let mut buf = [0; 32];
         let tok = self.read_token_str(&mut buf)?;
-        tok.parse().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+        tok.parse()
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
     }
 
     fn read_command_end(&mut self) -> Result<(), io::Error> {
         let mut buf = [0; 8];
         let tok = self.read_token(&mut buf)?;
-        if tok == b"$end" { Ok(()) } else { Err(InvalidData("expected $end").into()) }
+        if tok == b"$end" {
+            Ok(())
+        } else {
+            Err(InvalidData("expected $end").into())
+        }
     }
 
     fn read_string_command(&mut self) -> Result<String, io::Error> {
         let mut r = Vec::new();
         loop {
             r.push(self.read_byte()?);
-            if r.ends_with(b"$end") { break; }
+            if r.ends_with(b"$end") {
+                break;
+            }
         }
         let len = r.len() - 4;
         r.truncate(len);
@@ -109,9 +123,11 @@ impl<R: io::Read> Parser<R> {
     }
 
     fn read_reference_index_end(&mut self) -> Result<Option<ReferenceIndex>, io::Error> {
-        let mut buf = [0;32];
+        let mut buf = [0; 32];
         let tok = self.read_token_str(&mut buf)?;
-        if tok.as_bytes() == b"$end" { return Ok(None); }
+        if tok.as_bytes() == b"$end" {
+            return Ok(None);
+        }
 
         let index: ReferenceIndex = tok.parse()?;
         self.read_command_end()?;
@@ -127,7 +143,7 @@ impl<R: io::Read> Parser<R> {
 
         match cmd {
             b"comment" => Ok(Comment(self.read_string_command()?)),
-            b"date"    => Ok(Date(self.read_string_command()?)),
+            b"date" => Ok(Date(self.read_string_command()?)),
             b"version" => Ok(Version(self.read_string_command()?)),
             b"timescale" => {
                 let (mut buf, mut buf2) = ([0; 8], [0; 8]);
@@ -135,10 +151,12 @@ impl<R: io::Read> Parser<R> {
                 // Support both "1ps" and "1 ps"
                 let (num_str, unit_str) = match tok.find(|c: char| !c.is_numeric()) {
                     Some(idx) => (&tok[0..idx], &tok[idx..]),
-                    None => (tok, self.read_token_str(&mut buf2)?)
+                    None => (tok, self.read_token_str(&mut buf2)?),
                 };
                 self.read_command_end()?;
-                let quantity = num_str.parse().map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                let quantity = num_str
+                    .parse()
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
                 let unit = unit_str.parse()?;
                 Ok(Timescale(quantity, unit))
             }
@@ -179,7 +197,7 @@ impl<R: io::Read> Parser<R> {
                 }
             }
 
-            _ => Err(InvalidData("invalid keyword").into())
+            _ => Err(InvalidData("invalid keyword").into()),
         }
     }
 
@@ -192,7 +210,7 @@ impl<R: io::Read> Parser<R> {
         Ok(Command::Timestamp(self.read_token_parse()?))
     }
 
-    fn parse_scalar(&mut self, initial: u8) ->Result<Command, io::Error> {
+    fn parse_scalar(&mut self, initial: u8) -> Result<Command, io::Error> {
         let id = self.read_token_parse()?;
         let val = Value::parse(initial)?;
         Ok(Command::ChangeScalar(id, val))
@@ -203,7 +221,11 @@ impl<R: io::Read> Parser<R> {
         loop {
             let b = self.read_byte()?;
             if whitespace_byte(b) {
-                if val.len() > 0 { break; } else { continue; }
+                if val.len() > 0 {
+                    break;
+                } else {
+                    continue;
+                }
             }
             val.push(Value::parse(b)?);
         }
@@ -223,7 +245,11 @@ impl<R: io::Read> Parser<R> {
         Ok(Command::ChangeString(id, val))
     }
 
-    fn parse_scope(&mut self, scope_type: ScopeType, reference: String) -> Result<Scope, io::Error> {
+    fn parse_scope(
+        &mut self,
+        scope_type: ScopeType,
+        reference: String,
+    ) -> Result<Scope, io::Error> {
         use super::Command::*;
         let mut children = Vec::new();
 
@@ -234,17 +260,30 @@ impl<R: io::Read> Parser<R> {
                     children.push(ScopeItem::Scope(self.parse_scope(tp, id)?));
                 }
                 Some(Ok(VarDef(tp, size, id, r, idx))) => {
-                    children.push(ScopeItem::Var(
-                        Var { var_type: tp, size: size, code: id, reference: r , index: idx}
-                    ));
+                    children.push(ScopeItem::Var(Var {
+                        var_type: tp,
+                        size: size,
+                        code: id,
+                        reference: r,
+                        index: idx,
+                    }));
                 }
                 Some(Ok(_)) => return Err(InvalidData("unexpected command in $scope").into()),
                 Some(Err(e)) => return Err(e),
-                None => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "unexpected EOF with open $scope"))
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "unexpected EOF with open $scope",
+                    ))
+                }
             }
         }
 
-        Ok(Scope { scope_type: scope_type, identifier: reference, children: children })
+        Ok(Scope {
+            scope_type: scope_type,
+            identifier: reference,
+            children: children,
+        })
     }
 
     /// Parses the header of a VCD file into a `Header` struct.
@@ -257,25 +296,40 @@ impl<R: io::Read> Parser<R> {
         loop {
             match self.next() {
                 Some(Ok(Enddefinitions)) => break,
-                Some(Ok(Comment(s))) => { header.comment = Some(s); }
-                Some(Ok(Date(s)))    => { header.date    = Some(s); }
-                Some(Ok(Version(s))) => { header.version = Some(s); }
-                Some(Ok(Timescale(val, unit))) => { header.timescale = Some((val, unit)); }
+                Some(Ok(Comment(s))) => {
+                    header.comment = Some(s);
+                }
+                Some(Ok(Date(s))) => {
+                    header.date = Some(s);
+                }
+                Some(Ok(Version(s))) => {
+                    header.version = Some(s);
+                }
+                Some(Ok(Timescale(val, unit))) => {
+                    header.timescale = Some((val, unit));
+                }
                 Some(Ok(VarDef(var_type, size, code, reference, index))) => {
-                    header.items.push(ScopeItem::Var(
-                        Var { var_type, size, code, reference, index }
-                    ));
+                    header.items.push(ScopeItem::Var(Var {
+                        var_type,
+                        size,
+                        code,
+                        reference,
+                        index,
+                    }));
                 }
                 Some(Ok(ScopeDef(tp, id))) => {
-                    header.items.push(ScopeItem::Scope(
-                        self.parse_scope(tp, id)?
-                    ));
+                    header
+                        .items
+                        .push(ScopeItem::Scope(self.parse_scope(tp, id)?));
                 }
-                Some(Ok(_)) => {
-                    return Err(InvalidData("unexpected command in header").into())
-                }
+                Some(Ok(_)) => return Err(InvalidData("unexpected command in header").into()),
                 Some(Err(e)) => return Err(e),
-                None => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "unexpected end of VCD file before $enddefinitions"))
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "unexpected end of VCD file before $enddefinitions",
+                    ))
+                }
             }
         }
         Ok(header)
@@ -288,7 +342,7 @@ impl<P: io::Read> Iterator for Parser<P> {
         while let Some(b) = self.bytes_iter.next() {
             let b = match b {
                 Ok(b) => b,
-                Err(e) => return Some(Err(e))
+                Err(e) => return Some(Err(e)),
             };
             match b {
                 b' ' | b'\n' | b'\r' | b'\t' => (),
@@ -298,7 +352,11 @@ impl<P: io::Read> Iterator for Parser<P> {
                 b'b' | b'B' => return Some(self.parse_vector()),
                 b'r' | b'R' => return Some(self.parse_real()),
                 b's' | b'S' => return Some(self.parse_string()),
-                _ => return Some(Err(InvalidData("unexpected character at start of command").into()))
+                _ => {
+                    return Some(Err(
+                        InvalidData("unexpected character at start of command").into()
+                    ))
+                }
             }
         }
         None
@@ -307,14 +365,14 @@ impl<P: io::Read> Iterator for Parser<P> {
 
 #[cfg(test)]
 mod test {
-    use super::Var;
     use super::Command::*;
+    use super::Parser;
+    use super::ReferenceIndex;
+    use super::ScopeItem;
     use super::SimulationCommand::*;
     use super::Value::*;
-    use ::{ TimescaleUnit, IdCode, VarType, ScopeType };
-    use super::Parser;
-    use super::ScopeItem;
-    use super::ReferenceIndex;
+    use super::Var;
+    use {IdCode, ScopeType, TimescaleUnit, VarType};
 
     #[test]
     fn wikipedia_sample() {
@@ -448,7 +506,7 @@ $enddefinitions $end
         if let ScopeItem::Var(ref v) = scope.children[1] {
             assert_eq!(v.var_type, VarType::Wire);
             assert_eq!(&v.reference[..], "i_data");
-            assert_eq!(v.index, Some(ReferenceIndex::Range(9,0)));
+            assert_eq!(v.index, Some(ReferenceIndex::Range(9, 0)));
             assert_eq!(v.size, 10);
         } else {
             panic!("Expected Var, found {:?}", scope.children[0]);
@@ -570,20 +628,26 @@ b1 n0
         assert_eq!(header.version, None);
         assert_eq!(header.timescale, None);
 
-        assert_eq!(header.items[0], ScopeItem::Var(Var {
-            var_type: VarType::Integer,
-            size: 32,
-            code: IdCode(83),
-            reference: "smt_step".into(),
-            index: None,
-        }));
-        assert_eq!(header.items[1], ScopeItem::Var(Var {
-            var_type: VarType::Event,
-            size: 1,
-            code: IdCode(0),
-            reference: "smt_clock".into(),
-            index: None,
-        }));
+        assert_eq!(
+            header.items[0],
+            ScopeItem::Var(Var {
+                var_type: VarType::Integer,
+                size: 32,
+                code: IdCode(83),
+                reference: "smt_step".into(),
+                index: None,
+            })
+        );
+        assert_eq!(
+            header.items[1],
+            ScopeItem::Var(Var {
+                var_type: VarType::Event,
+                size: 1,
+                code: IdCode(0),
+                reference: "smt_clock".into(),
+                index: None,
+            })
+        );
 
         let scope = match &header.items[2] {
             ScopeItem::Scope(sc) => sc,
@@ -604,7 +668,13 @@ b1 n0
         let expected = &[
             Timestamp(0),
             ChangeScalar(IdCode(0), V1),
-            ChangeVector(IdCode(83), vec![V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0]),
+            ChangeVector(
+                IdCode(83),
+                vec![
+                    V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0,
+                    V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0,
+                ],
+            ),
             ChangeVector(IdCode(1581), vec![V1]),
             ChangeVector(IdCode(1675), vec![V0, V0, V0, V0, V0, V0, V0, V0]),
             ChangeVector(IdCode(1769), vec![V0]),
@@ -621,7 +691,13 @@ b1 n0
             ChangeVector(IdCode(1581), vec![V0]),
             Timestamp(10),
             ChangeScalar(IdCode(0), V1),
-            ChangeVector(IdCode(83), vec![V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V1]),
+            ChangeVector(
+                IdCode(83),
+                vec![
+                    V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0,
+                    V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V1,
+                ],
+            ),
             ChangeVector(IdCode(1581), vec![V1]),
             ChangeVector(IdCode(1675), vec![V0, V0, V0, V0, V0, V0, V0, V0]),
             ChangeVector(IdCode(1769), vec![V0]),
@@ -638,7 +714,13 @@ b1 n0
             ChangeVector(IdCode(1581), vec![V0]),
             Timestamp(20),
             ChangeScalar(IdCode(0), V1),
-            ChangeVector(IdCode(83), vec![V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V1, V0]),
+            ChangeVector(
+                IdCode(83),
+                vec![
+                    V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V0,
+                    V0, V0, V0, V0, V0, V0, V0, V0, V0, V0, V1, V0,
+                ],
+            ),
             ChangeVector(IdCode(1581), vec![V1]),
         ];
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -2,7 +2,9 @@ use super::InvalidData;
 use std::io;
 use std::str::{from_utf8, FromStr};
 
-use {Command, Header, ReferenceIndex, Scope, ScopeItem, ScopeType, SimulationCommand, Value, Var};
+use crate::{
+    Command, Header, ReferenceIndex, Scope, ScopeItem, ScopeType, SimulationCommand, Value, Var,
+};
 
 fn whitespace_byte(b: u8) -> bool {
     match b {
@@ -372,7 +374,7 @@ mod test {
     use super::SimulationCommand::*;
     use super::Value::*;
     use super::Var;
-    use {IdCode, ScopeType, TimescaleUnit, VarType};
+    use crate::{IdCode, ScopeType, TimescaleUnit, VarType};
 
     #[test]
     fn wikipedia_sample() {

--- a/src/write.rs
+++ b/src/write.rs
@@ -21,7 +21,7 @@ impl<'s> Writer<'s> {
     /// ```
     pub fn new(writer: &mut dyn io::Write) -> Writer<'_> {
         Writer {
-            writer: writer,
+            writer,
             next_id_code: IdCode::FIRST,
             scope_depth: 0,
         }


### PR DESCRIPTION
[nMigen](https://github.com/nmigen/nmigen) uses the `string` type for enum-valued signals and for the state of finite state machines.

This pull request depends on #9 

Example vcd file:
```vcd
$comment Generated by nMigen $end
$date 2020-07-09 22:03:33.296344 $end
$timescale 100 ps $end
$scope module top $end
$var wire 1 ! clk $end
$var wire 1 " rst $end
$var wire 5 # ctr $end
$var wire 1 $ stb $end
$var wire 1 % err $end
$var string 1 & fsm_state $end
$var wire 3 ' bit $end
$var wire 8 ( data $end
$var wire 1 ) rdy $end
$var wire 1 * i $end
$var wire 1 + ack $end
$upscope $end
$enddefinitions $end
#0
$dumpvars
0!
0"
b0 #
0$
0%
sSTART/0 &
b0 '
b0 (
0)
0*
0+
$end
#5000
1$
#10000
```

Generated using (in a Python 3.6 venv on Ubuntu 18.04):
```bash
git clone https://github.com/nmigen/nmigen.git
cd nmigen
git checkout 30e2f91176edcd1c8766c2cb11f413b9c77936b9
python setup.py develop
python examples/basic/fsm.py simulate -v fsm.vcd -c 1
```