### PR TITLE
Writer: Take io::Write directly, not a mutable reference

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -6,20 +6,20 @@ use crate::{
 };
 
 /// Struct wrapping an `io::Write` with methods for writing VCD commands and data.
-pub struct Writer<'w> {
-    writer: &'w mut dyn io::Write,
+pub struct Writer<W: io::Write> {
+    writer: W,
     next_id_code: IdCode,
     scope_depth: usize,
 }
 
-impl<'s> Writer<'s> {
+impl<W: io::Write> Writer<W> {
     /// Creates a Writer, wrapping an io::Write.
     ///
     /// ```
     /// let mut buf = Vec::new();
     /// let mut vcd = vcd::Writer::new(&mut buf);
     /// ```
-    pub fn new(writer: &mut dyn io::Write) -> Writer<'_> {
+    pub fn new(writer: W) -> Writer<W> {
         Writer {
             writer,
             next_id_code: IdCode::FIRST,


### PR DESCRIPTION
Taking a mutable reference forces users to always have a mutable reference to the inner `Write` instance that must outlive the `Writer` instance. This is inconvenient because it disallows a user to properly wrap a `Writer` instance in another struct without forcing the outer struct to _also_ accept a mutable reference, and it's actually unnecessary, since `Write` is implemented for `&mut Write`. Additionally, we're forced to use dynamic dispatch for the underlying `Write` instance, which is likely to be inefficient.

This shouldn't be a breaking change for most user code since `Write` is implemented for `&mut Write`, although code which wraps a `Writer` today will need to change to reflect the new generic parameter instead of the old lifetime.

This is conformant with C-RW-VALUE in the Rust API guidelines (https://rust-lang.github.io/api-guidelines/interoperability.html#generic-readerwriter-functions-take-r-read-and-w-write-by-value-c-rw-value).