### PR TITLE
Fix negative index register

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -404,6 +404,7 @@ impl Default for Scope {
 }
 
 /// Index of a VCD variable reference, either a bit select index `[i]` or a range index `[msb:lsb]`
+/// Negative index discard the sign
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum ReferenceIndex {
     BitSelect(u32),
@@ -415,7 +416,7 @@ impl FromStr for ReferenceIndex {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use std::io::{Error, ErrorKind};
         use ReferenceIndex::*;
-        let s = s.trim_start_matches('[').trim_start_matches('-').trim_end_matches(']');
+        let s = s.trim_start_matches(['[', '-']).trim_end_matches(']');
         match s.find(':') {
             Some(idx) => {
                 let msb: u32 = s[..idx]
@@ -423,7 +424,7 @@ impl FromStr for ReferenceIndex {
                     .parse()
                     .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
                 let lsb: u32 = s[idx..]
-                    .trim_start_matches(':')
+                    .trim_start_matches([':', '-'])
                     .trim()
                     .parse()
                     .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,3 +644,25 @@ impl Header {
         scope.find_var(path[path.len() - 1].borrow())
     }
 }
+
+
+#[cfg(test)]
+mod test{
+    use std::str::FromStr;
+
+    use crate::ReferenceIndex;
+
+    #[test]
+    fn test_negative_ref_index(){
+        let tests : &[(i32, i32)] = &[(-1, 0), (0, -1), (-1, -1)];
+        for (tstart, tstop) in tests{
+            match ReferenceIndex::from_str(&format!("[{tstart}:{tstop}]")).unwrap(){
+                ReferenceIndex::BitSelect(_) => panic!("Must be range"),
+                ReferenceIndex::Range(start, stop) => {
+                    assert_eq!(start, tstart.unsigned_abs());
+                    assert_eq!(stop, tstop.unsigned_abs());
+                },
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -415,7 +415,7 @@ impl FromStr for ReferenceIndex {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use std::io::{Error, ErrorKind};
         use ReferenceIndex::*;
-        let s = s.trim_start_matches('[').trim_end_matches(']');
+        let s = s.trim_start_matches('[').trim_start_matches('-').trim_end_matches(']');
         match s.find(':') {
             Some(idx) => {
                 let msb: u32 = s[..idx]


### PR DESCRIPTION
Iverilog icarus create negative index for some reasons. GTKWave just ignore this. I think need do same