### PR TITLE
impl From<IdCode> for u64

### DIFF
--- a/src/idcode.rs
+++ b/src/idcode.rs
@@ -80,6 +80,12 @@ impl From<u64> for IdCode {
     }
 }
 
+impl From<IdCode> for u64 {
+    fn from(i: IdCode) -> u64 {
+        i.0
+    }
+}
+
 impl Display for IdCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut i = self.0;


### PR DESCRIPTION
Hi!

I'm using this in a project, to be able to map IdCode to Vec/slice indices, which is more efficient than using other datastructures (e.g. `HashMap<IdCode, _>`).